### PR TITLE
LLaMA prompting: use itertools grouping rather than string buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ for many more.
 
 [Read the docs on ReadTheDocs!](http://kani.readthedocs.io/)
 
-[Read our preprint on arXiv!](https://arxiv.org/abs/2309.05542)
+[Read our paper on arXiv!](https://arxiv.org/abs/2309.05542)
 
 ## Features
 
@@ -171,6 +171,8 @@ Simply click on the latest build to see LLaMA's output!
 
 ## Kani in the News
 
+Kani will appear at the NLP Open Source Software workshop at EMNLP 2023!
+
 We are really excited and grateful to see people talking about Kani online. We are also trending on Papers With Code,
 GitHub, and OSS Insight. Check out some recent articles and videos below!
 
@@ -225,23 +227,7 @@ We would like to thank the members of the lab of Chris Callison-Burch for their 
 contents of both our paper and the Kani repository. In addition, we’d like to thank Henry Zhu (no relation to the first
 author) for his early and enthusiastic support of the project.
 
-This research is based upon work supported in part by the IARPA HIATUS Program (contract 2022-22072200005), and the
-NSF (Award 1928631). Approved for Public Release, Distribution Unlimited. The views and conclusions contained herein are
-those of the authors and should not be interpreted as necessarily representing the official policies, either expressed
-or implied, of IARPA, NSF, or the U.S. Government.
-
-<!--
-For developers:
-
-## Build and Publish
-
-`fastlmi` uses Hatchling to build.
-
-Make sure to bump the version in pyproject.toml before publishing.
-
-```shell
-rm -r dist/
-python -m build
-python -m twine upload dist/*
-```
--->
+This research is based upon work supported in part by the Air Force Research Laboratory (contract FA8750-23-C-0507), the
+IARPA HIATUS Program (contract 2022-22072200005), and the NSF (Award 1928631). Approved for Public Release, Distribution
+Unlimited. The views and conclusions contained herein are those of the authors and should not be interpreted as
+necessarily representing the official policies, either expressed or implied, of IARPA, NSF, or the U.S. Government.

--- a/kani/__init__.py
+++ b/kani/__init__.py
@@ -4,3 +4,6 @@ from .internal import ExceptionHandleResult, FunctionCallResult
 from .kani import Kani
 from .models import ChatMessage, ChatRole, FunctionCall, MessagePart
 from .utils.cli import chat_in_terminal, chat_in_terminal_async
+
+# declare that kani is also a namespace package
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/kani/engines/ctransformers/llama2.py
+++ b/kani/engines/ctransformers/llama2.py
@@ -1,3 +1,5 @@
+import functools
+
 from kani.ai_function import AIFunction
 from kani.models import ChatMessage, ChatRole
 from .base import CTransformersEngine
@@ -79,7 +81,10 @@ class LlamaCTransformersEngine(CTransformersEngine):
         super().__init__(model_id, model_file, *args, **kwargs)
 
     def build_prompt(self, messages: list[ChatMessage], functions: list[AIFunction] | None = None) -> list[int]:
-        return llama2_prompt.build(messages, tokenize=self.model.tokenize, eos_token_id=self.model.eos_token_id)
+        tokenize = functools.partial(self.model.tokenize, add_bos_token=False)
+        return llama2_prompt.build(
+            messages, tokenize=tokenize, bos_token_id=self.model.bos_token_id, eos_token_id=self.model.eos_token_id
+        )
 
     def message_len(self, message: ChatMessage) -> int:
         # https://github.com/facebookresearch/llama/blob/main/llama/generation.py#L212

--- a/kani/engines/llama2_prompt.py
+++ b/kani/engines/llama2_prompt.py
@@ -3,7 +3,8 @@
 This file is responsible for implementing the common non-strict ChatMessage to tokens translation, while handling
 the nuance of the INST and SYS tokens as best as possible.
 """
-from typing import Callable
+import itertools
+from typing import Callable, Iterable
 
 from kani.models import ChatMessage, ChatRole
 
@@ -11,25 +12,36 @@ B_INST, E_INST = "[INST]", "[/INST]"
 B_SYS, E_SYS = "<<SYS>>\n", "\n<</SYS>>\n\n"
 
 
-def build(messages: list[ChatMessage], tokenize: Callable[[str], list[int]], eos_token_id: int = 2) -> list[int]:
+def build(
+    messages: list[ChatMessage], tokenize: Callable[[str], list[int]], bos_token_id: int = 1, eos_token_id: int = 2
+) -> list[int]:
+    """Build the tokens for a list of messages. `tokenize` should tokenize a str without special tokens."""
     tokens = []
-    prompt_buf = []  # parts of the user-assistant pair
-    for message in messages:
-        if message.role == ChatRole.USER:
-            prompt_buf.append(f"{B_INST} {message.text} {E_INST}")
-        elif message.role == ChatRole.ASSISTANT:
-            prompt_buf.append(f" {message.text} ")
-            # turn the current round into tokens
-            prompt_round = "".join(prompt_buf)
-            # hack: if we see a " {E_INST}{B_INST} " we should replace it with empty string
-            # (it happens immediately after a system + user message)
-            prompt_round.replace(f" {E_INST}{B_INST} ", "")
-            tokens.extend(tokenize(prompt_round))  # assumption: tokenize() adds the BOS token but not the EOS token
+    for content, bos, eos in build_str(messages):
+        if bos:
+            tokens.append(bos_token_id)
+        tokens.extend(tokenize(content))
+        if eos:
             tokens.append(eos_token_id)
-            prompt_buf.clear()
-        else:
-            prompt_buf.append(f"{B_INST} {B_SYS}{message.text}{E_SYS} {E_INST}")
-    # flush rest of prompt buffer (probably a user message) into tokens
-    if prompt_buf:
-        tokens.extend(tokenize("".join(prompt_buf)))
     return tokens
+
+
+def build_str(messages: list[ChatMessage]) -> Iterable[tuple[str, bool]]:
+    """Given a list of messages, yield a list of pairs of (content string, bos, eos)."""
+    # combine consecutive instruction messages and non-instruction messages
+    for is_inst, role_messages in itertools.groupby(
+        messages, key=lambda m: m.role == ChatRole.USER or m.role == ChatRole.SYSTEM
+    ):
+        # get content within tags (if any)
+        content = []
+        for message in role_messages:
+            if message.role == ChatRole.SYSTEM:
+                content.append(f"{B_SYS}{message.text}{E_SYS}")
+            else:
+                content.append(message.text)
+        # if the content is an instruction, return it wrapped in inst tags; otherwise don't
+        content_str = "".join(content)
+        if is_inst:
+            yield f"{B_INST} {content_str} {E_INST}", True, False
+        else:
+            yield f" {content_str} ", False, True

--- a/kani/engines/llama2_prompt.py
+++ b/kani/engines/llama2_prompt.py
@@ -26,7 +26,7 @@ def build(
     return tokens
 
 
-def build_str(messages: list[ChatMessage]) -> Iterable[tuple[str, bool]]:
+def build_str(messages: list[ChatMessage]) -> Iterable[tuple[str, bool, bool]]:
     """Given a list of messages, yield a list of pairs of (content string, bos, eos)."""
     # combine consecutive instruction messages and non-instruction messages
     for is_inst, role_messages in itertools.groupby(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ openai = [
 ]
 
 ctransformers = [
-    "ctransformers~=0.2.14",
+    "ctransformers>=0.2.25,<1.0.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ torch  # ;extra == 'huggingface'
 transformers>=4.0.0,<5.0.0  # ;extra == 'huggingface'
 sentencepiece~=0.1.99  # ;extra == 'llama'
 tiktoken>=0.4.0,<1.0.0  # ;extra == 'openai'
-ctransformers~=0.2.14  # ;extra == 'ctransformers'
+ctransformers>=0.2.25,<1.0.0  # ;extra == 'ctransformers'
 
 # dev
 black

--- a/tests/test_llama2_prompt.py
+++ b/tests/test_llama2_prompt.py
@@ -1,0 +1,88 @@
+"""Tests to ensure the LLaMA v2 prompt is correct."""
+from kani import ChatMessage
+from kani.engines.llama2_prompt import build_str
+
+
+def prompt_str(messages: list[ChatMessage]) -> str:
+    out = ""
+    for content, bos, eos in build_str(messages):
+        if bos:
+            out += "<s>"
+        out += content
+        if eos:
+            out += "</s>"
+    return out
+
+
+def test_basic():
+    messages = [
+        ChatMessage.user("Hello there."),
+        ChatMessage.assistant("General Kenobi."),
+    ]
+    expected = "<s>[INST] Hello there. [/INST] General Kenobi. </s>"
+    assert prompt_str(messages) == expected
+
+    messages = [
+        ChatMessage.system("I am a system message."),
+        ChatMessage.user("Hello there."),
+        ChatMessage.assistant("General Kenobi."),
+    ]
+    expected = "<s>[INST] <<SYS>>\nI am a system message.\n<</SYS>>\n\nHello there. [/INST] General Kenobi. </s>"
+    assert prompt_str(messages) == expected
+
+
+def test_2round():
+    messages = [
+        ChatMessage.system("I am a system message."),
+        ChatMessage.user("Hello there."),
+        ChatMessage.assistant("General Kenobi."),
+        ChatMessage.user("I am:"),
+        ChatMessage.assistant("a potato."),
+    ]
+    expected = (
+        "<s>[INST] <<SYS>>\nI am a system message.\n<</SYS>>\n\nHello there. [/INST] General Kenobi. </s>"
+        "<s>[INST] I am: [/INST] a potato. </s>"
+    )
+    assert prompt_str(messages) == expected
+
+
+def test_2system():
+    messages = [
+        ChatMessage.system("I am a system message."),
+        ChatMessage.system("But wait, there's more."),
+        ChatMessage.user("Hello there."),
+        ChatMessage.assistant("General Kenobi."),
+    ]
+    expected = (
+        "<s>[INST] <<SYS>>\nI am a system message.\n<</SYS>>\n\n"
+        "<<SYS>>\nBut wait, there's more.\n<</SYS>>\n\nHello there. [/INST] General Kenobi. </s>"
+    )
+    assert prompt_str(messages) == expected
+
+
+def test_2user():
+    messages = [
+        ChatMessage.system("I am a system message."),
+        ChatMessage.user("Hello there."),
+        ChatMessage.user("I am another message."),
+        ChatMessage.assistant("General Kenobi."),
+    ]
+    expected = (
+        "<s>[INST] <<SYS>>\nI am a system message.\n<</SYS>>\n\n"
+        "Hello there.I am another message. [/INST] General Kenobi. </s>"
+    )
+    assert prompt_str(messages) == expected
+
+
+def test_2asst():
+    messages = [
+        ChatMessage.system("I am a system message."),
+        ChatMessage.user("Hello there."),
+        ChatMessage.assistant("General Kenobi."),
+        ChatMessage.assistant("I am another message."),
+    ]
+    expected = (
+        "<s>[INST] <<SYS>>\nI am a system message.\n<</SYS>>\n\n"
+        "Hello there. [/INST] General Kenobi.I am another message. </s>"
+    )
+    assert prompt_str(messages) == expected


### PR DESCRIPTION
This improves the mechanism by which LLaMAv2 prompts are built to use an itertools group rather than a string buffer to merge consecutive system-user messages (which both need to be wrapped in a single `[INST] [/INST]` tag).

The PR also adds tests to assert that the prompt is built correctly (which you can view to see the expected grouping behaviour).