### PR TITLE
Allow multiple tool calls per ChatMessage

### DIFF
--- a/kani/models.py
+++ b/kani/models.py
@@ -234,7 +234,7 @@ class ChatMessage(BaseModel):
     tool_call_id: str | None = None
     """The ID for a requested :class:`.ToolCall` which this message is a response to (function messages only)."""
 
-    tool_calls: tuple[ToolCall] | None = None
+    tool_calls: tuple[ToolCall, ...] | None = None
     """The tool calls requested by the model (assistant messages only)."""
 
     @property

--- a/tests/test_chatmessage.py
+++ b/tests/test_chatmessage.py
@@ -75,6 +75,7 @@ def test_copy_tools():
     with pytest.raises(ValueError):
         msg.copy_with(tool_calls=[bar_call], function_call=bar_call.function)
 
+
 def test_support_multiple_tool_calls():
     tool_call1 = ToolCall.from_function("foo")
     tool_call2 = ToolCall.from_function("bar")

--- a/tests/test_chatmessage.py
+++ b/tests/test_chatmessage.py
@@ -74,3 +74,11 @@ def test_copy_tools():
 
     with pytest.raises(ValueError):
         msg.copy_with(tool_calls=[bar_call], function_call=bar_call.function)
+
+def test_support_multiple_tool_calls():
+    tool_call1 = ToolCall.from_function("foo")
+    tool_call2 = ToolCall.from_function("bar")
+
+    msg = ChatMessage(role="function", content=None, tool_calls=[tool_call1, tool_call2])
+
+    assert msg.tool_calls == (tool_call1, tool_call2)


### PR DESCRIPTION
This PR addresses a bug where a ChatMessage containing multiple ToolCall objects would result in a validation error due to Pydantic's tuple length constraint[0]. The `tool_calls` field's type annotation was updated to allow a variable-length tuple.

Before:
```
➜ python3 start.py
USER: get me the SEA weather in F and C
Traceback (most recent call last):
 [truncated]
pydantic_core._pydantic_core.ValidationError: 1 validation error for ChatMessage
tool_calls
  Tuple should have at most 1 item after validation, not 2 [type=too_long, input_value=[ToolCall(id='call_iQLAkv...unit": "fahrenheit"}'))], input_type=list]
    For further information visit https://errors.pydantic.dev/2.5/v/too_long
```

After:

```
➜ python3 start.py
USER: get me the SEA weather in F and C
AI: Thinking (get_weather)...
AI: The current weather in Seattle, WA is sunny. It is 72 degrees Fahrenheit and 22 degrees Celsius.
```

[0] `Tuple should have at most 1 item after validation, not 2 [type=too_long, input_value=[ToolCall(id='call_iQLAkv...unit": "fahrenheit"}'))], input_type=list]`