### PR TITLE
Add improvements to chat_in_terminal

### DIFF
--- a/kani/kani.py
+++ b/kani/kani.py
@@ -123,7 +123,8 @@ class Kani:
 
         This is slightly faster when you are chatting with a kani with no AI functions defined.
 
-        :param query: The contents of the user's chat message.
+        :param query: The contents of the user's chat message. Can be None to generate a completion without a user
+            prompt.
         :param kwargs: Additional arguments to pass to the model engine (e.g. hyperparameters).
         :returns: The model's reply.
         """
@@ -138,7 +139,8 @@ class Kani:
         # do the chat round
         async with self.lock:
             # add the user's chat input to the state
-            await self.add_to_history(ChatMessage.user(query))
+            if query is not None:
+                await self.add_to_history(ChatMessage.user(query))
 
             # and get a completion
             completion = await self.get_model_completion(**kwargs)
@@ -162,13 +164,15 @@ class Kani:
             async for msg in kani.full_round("How's the weather?"):
                 print(msg.text)
 
-        :param query: The content of the user's chat message.
+        :param query: The content of the user's chat message. Can be None to generate a completion without a user
+            prompt.
         :param kwargs: Additional arguments to pass to the model engine (e.g. hyperparameters).
         """
         retry = 0
         is_model_turn = True
         async with self.lock:
-            await self.add_to_history(ChatMessage.user(query))
+            if query is not None:
+                await self.add_to_history(ChatMessage.user(query))
 
             while is_model_turn:
                 # do the model prediction

--- a/kani/models.py
+++ b/kani/models.py
@@ -16,7 +16,7 @@ MESSAGEPART_TYPE_KEY = "__kani_messagepart_type__"  # used for serdes of Message
 
 # ==== typing ====
 MessagePartType: TypeAlias = Union["MessagePart", str]  # ChatMessage.parts[*]
-QueryType: TypeAlias = str | Sequence[MessagePartType]  # Kani.*_round(...)
+QueryType: TypeAlias = str | Sequence[MessagePartType] | None  # Kani.*_round(...)
 
 
 class BaseModel(PydanticBase, abc.ABC):

--- a/kani/utils/cli.py
+++ b/kani/utils/cli.py
@@ -8,7 +8,7 @@ from kani.kani import Kani
 from kani.utils.message_formatters import assistant_message_contents_thinking
 
 
-async def chat_in_terminal_async(kani: Kani, rounds: int = 0, stopword: str = None):
+async def chat_in_terminal_async(kani: Kani, *, rounds: int = 0, stopword: str = None):
     """Async version of :func:`.chat_in_terminal`.
     Use in environments when there is already an asyncio loop running (e.g. Google Colab).
     """
@@ -30,7 +30,7 @@ async def chat_in_terminal_async(kani: Kani, rounds: int = 0, stopword: str = No
         await kani.engine.close()
 
 
-def chat_in_terminal(kani: Kani, rounds: int = 0, stopword: str = None):
+def chat_in_terminal(kani: Kani, **kwargs):
     """Chat with a kani right in your terminal.
 
     Useful for playing with kani, quick prompt engineering, or demoing the library.
@@ -61,4 +61,4 @@ def chat_in_terminal(kani: Kani, rounds: int = 0, stopword: str = None):
                 f" should use `await chat_in_terminal_async(...)` instead or install `nest-asyncio`."
             )
             return
-    asyncio.run(chat_in_terminal_async(kani, rounds=rounds, stopword=stopword))
+    asyncio.run(chat_in_terminal_async(kani, **kwargs))

--- a/kani/utils/cli.py
+++ b/kani/utils/cli.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 import textwrap
+from typing import overload
 
 from kani.kani import Kani
 from kani.models import ChatRole
@@ -58,6 +59,21 @@ async def chat_in_terminal_async(
         pass
     finally:
         await kani.engine.close()
+
+
+@overload
+def chat_in_terminal(
+    kani: Kani,
+    *,
+    rounds: int = 0,
+    stopword: str = None,
+    echo: bool = False,
+    ai_first: bool = False,
+    width: int = None,
+    show_function_args: bool = False,
+    show_function_returns: bool = False,
+    verbose: bool = False,
+): ...
 
 
 def chat_in_terminal(kani: Kani, **kwargs):

--- a/kani/utils/message_formatters.py
+++ b/kani/utils/message_formatters.py
@@ -19,14 +19,33 @@ def assistant_message_contents(msg: ChatMessage):
         return msg.text
 
 
-def assistant_message_contents_thinking(msg: ChatMessage):
-    """Return the content of any assistant message, and "Thinking..." on function calls."""
-    if msg.role == ChatRole.ASSISTANT:
-        text = msg.text
-        if msg.tool_calls and text:
-            called_functions = ", ".join(tc.function.name for tc in msg.tool_calls)
-            return f"{text}\n    Thinking ({called_functions})..."
-        elif msg.tool_calls:
-            called_functions = ", ".join(tc.function.name for tc in msg.tool_calls)
-            return f"Thinking ({called_functions})..."
-        return text
+def assistant_message_contents_thinking(msg: ChatMessage, show_args=False):
+    """Return the content of any assistant message, and "Thinking..." on function calls.
+
+    If *show_args* is True, include the arguments to each function call.
+    You can use this in ``full_round_str`` by using a partial, e.g.:
+    ``ai.full_round_str(..., message_formatter=functools.partial(assistant_message_contents_thinking, show_args=True))``
+    """
+    if msg.role != ChatRole.ASSISTANT:
+        return
+
+    # text
+    text = msg.text or ""
+
+    # function calls
+    if not msg.tool_calls:
+        function_calls = ""
+    else:
+        # with args: show a nice repr (e.g. `get_weather(location="San Francisco, CA", unit="fahrenheit")`)
+        if show_args:
+            parts = []
+            for tc in msg.tool_calls:
+                args = ", ".join(f"{kwarg}={v!r}" for kwarg, v in tc.function.kwargs.items())
+                parts.append(f"{tc.function.name}({args})")
+            called_functions = "; ".join(parts)
+        # no args: just print the function name
+        else:
+            called_functions = "; ".join(tc.function.name for tc in msg.tool_calls)
+        function_calls = f"Thinking... [{called_functions}]"
+
+    return text + function_calls


### PR DESCRIPTION
Resolves #33 

Adds the following kwargs to `chat_in_terminal`:

    :param bool echo: Whether to echo the user's input to stdout after they send a message (e.g. to save in interactive
        notebook outputs; default false)
    :param bool ai_first: Whether the user should send the first message (default) or the model should generate a
        completion before prompting the user for a message.
    :param int width: The maximum width of the printed outputs (default unlimited).
    :param bool show_function_args: Whether to print the arguments the model is calling functions with for each call
        (default false).
    :param bool show_function_returns: Whether to print the results of each function call (default false).
    :param bool verbose: Equivalent to setting ``echo``, ``show_function_args``, and ``show_function_returns`` to True.