### PR TITLE
Kani save/load improvements

### DIFF
--- a/kani/kani.py
+++ b/kani/kani.py
@@ -3,7 +3,8 @@ import inspect
 import logging
 import warnings
 from collections.abc import AsyncIterable
-from typing import Callable
+from pathlib import Path
+from typing import Callable, Literal
 
 from .ai_function import AIFunction
 from .engines.base import BaseCompletion, BaseEngine
@@ -11,8 +12,9 @@ from .exceptions import FunctionCallException, MessageTooLong, NoSuchFunction, W
 from .internal import ExceptionHandleResult, FunctionCallResult
 from .models import ChatMessage, ChatRole, FunctionCall, QueryType, ToolCall
 from .streaming import DummyStream, StreamManager
+from .utils import saveload
 from .utils.message_formatters import assistant_message_contents
-from .utils.typing import PathLike, SavedKani
+from .utils.typing import PathLike
 
 log = logging.getLogger("kani")
 message_log = logging.getLogger("kani.messages")
@@ -542,27 +544,28 @@ class Kani:
         self.chat_history.append(message)
 
     # ==== utility methods ====
-    def save(self, fp: PathLike, **kwargs):
-        """Save the chat state of this kani to a JSON file. This will overwrite the file if it exists!
+    def save(self, fp: PathLike, *, save_format: Literal["json", "kani"] | None = None, **kwargs):
+        """
+        Save the chat state of this kani to a ``.kani`` file or JSON. This will overwrite the file if it exists!
 
         :param fp: The path to the file to save.
+        :param save_format: Whether to save the chat state as a ``.kani`` file or JSON. If not set, determines format
+            by file path extension (defaulting to ``.kani`` if uncertain).
         :param kwargs: Additional arguments to pass to Pydantic's ``model_dump_json``.
         """
-        # TODO save to a .kani file for multimodal attachments
-        # zip w/ manifest file
-        data = SavedKani(always_included_messages=self.always_included_messages, chat_history=self.chat_history)
-        with open(fp, "w", encoding="utf-8") as f:
-            f.write(data.model_dump_json(**kwargs))
+        if save_format is None:
+            save_format = "json" if Path(fp).suffix == ".json" else "kani"
+        return saveload.save(fp, inst=self, save_format=save_format, **kwargs)
 
     def load(self, fp: PathLike, **kwargs):
-        """Load chat state from a JSON file into this kani. This will overwrite any existing chat state!
+        """
+        Load a chat state from a ``.kani`` file or JSON file into this instance.
+        This will overwrite any existing chat state!
 
         :param fp: The path to the file containing the chat state.
         :param kwargs: Additional arguments to pass to Pydantic's ``model_validate_json``.
         """
-        with open(fp, encoding="utf-8") as f:
-            data = f.read()
-        state = SavedKani.model_validate_json(data, **kwargs)
+        state = saveload.load(fp, **kwargs)
         self.always_included_messages = state.always_included_messages
         self.chat_history = state.chat_history
 

--- a/kani/models.py
+++ b/kani/models.py
@@ -8,7 +8,7 @@ import warnings
 from functools import cached_property
 from typing import Any, ClassVar, Sequence, Type, TypeAlias, Union
 
-from pydantic import BaseModel as PydanticBase, field_serializer, model_serializer, model_validator
+from pydantic import BaseModel as PydanticBase, SerializeAsAny, model_serializer, model_validator
 
 from .exceptions import MissingMessagePartType
 
@@ -159,7 +159,7 @@ class MessagePart(BaseModel, abc.ABC):
     # noinspection PyNestedDecorators
     @model_validator(mode="wrap")
     @classmethod
-    def _validate(cls, v, nxt):
+    def _validate(cls, v, nxt, info):
         """If we are deserializing a dict with the special key, switch to the right class' validator."""
         if isinstance(v, dict) and MESSAGEPART_TYPE_KEY in v:
             fqn = v.pop(MESSAGEPART_TYPE_KEY)
@@ -171,7 +171,7 @@ class MessagePart(BaseModel, abc.ABC):
                     f"Found a MessagePart with type {fqn!r}, but the type is not defined. Maybe the type is from an"
                     " extension that has not yet been imported?",
                 )
-            return klass.model_validate(v)
+            return klass.model_validate(v, context=info.context)
         return nxt(v)
 
     # ==== entrypoints ====
@@ -198,19 +198,11 @@ class MessagePart(BaseModel, abc.ABC):
 class ChatMessage(BaseModel):
     """Represents a message in the chat context."""
 
-    def __init__(self, **kwargs):
-        # translate a function_call into tool_calls
-        if "function_call" in kwargs:
-            if "tool_calls" in kwargs:
-                raise ValueError("Only one of `function_call` or `tool_calls` may be provided.")
-            kwargs["tool_calls"] = (ToolCall.from_function_call(kwargs.pop("function_call")),)
-        super().__init__(**kwargs)
-
     role: ChatRole
     """Who said the message?"""
 
     # ==== content ====
-    content: str | list[MessagePart | str] | None
+    content: str | list[SerializeAsAny[MessagePart] | str] | None
     """The data used to create this message. Generally, you should use :attr:`text` or :attr:`parts` instead."""
 
     @property
@@ -330,19 +322,14 @@ class ChatMessage(BaseModel):
         return super().copy_with(**new_values)
 
     # ==== pydantic stuff ====
-    @field_serializer("content", mode="wrap")
-    def _content_serializer(self, content, nxt):
-        """
-        Custom serialization logic for a list of MessageParts due to
-        https://docs.pydantic.dev/latest/concepts/serialization/#subclass-instances-for-fields-of-basemodel-dataclasses-typeddict
-        """
-        if not isinstance(content, list):
-            return nxt(content)
-
-        out = []
-        for item in content:
-            if isinstance(item, MessagePart):
-                out.append(item.model_dump())
-            else:
-                out.append(nxt(item))
-        return out
+    # noinspection PyNestedDecorators
+    @model_validator(mode="wrap")
+    @classmethod
+    def _validate_function_call(cls, v, nxt):
+        if isinstance(v, dict):
+            # translate a function_call into tool_calls if it's passed to __init__
+            if "function_call" in v:
+                if "tool_calls" in v:
+                    raise ValueError("Only one of `function_call` or `tool_calls` may be provided.")
+                v["tool_calls"] = (ToolCall.from_function_call(v.pop("function_call")),)
+        return nxt(v)

--- a/kani/models.py
+++ b/kani/models.py
@@ -141,14 +141,20 @@ class MessagePart(BaseModel, abc.ABC):
             )
         cls._messagepart_registry[fqn] = cls
 
+    def _get_typekey_dict(self):
+        """
+        Get the additional key(s) needed for serialization.
+        Used if a ModelPart implements special serialization logic.
+        """
+        cls = type(self)
+        fqn = cls.__module__ + "." + cls.__qualname__
+        return {MESSAGEPART_TYPE_KEY: fqn}
+
     @model_serializer(mode="wrap")
     def _serialize(self, nxt):
         """Extend the default serialization dict with a key recording what type it is."""
         retval = nxt(self)
-        cls = type(self)
-        fqn = cls.__module__ + "." + cls.__qualname__
-        retval[MESSAGEPART_TYPE_KEY] = fqn
-        return retval
+        return retval | self._get_typekey_dict()
 
     # noinspection PyNestedDecorators
     @model_validator(mode="wrap")

--- a/kani/utils/saveload.py
+++ b/kani/utils/saveload.py
@@ -1,0 +1,97 @@
+import dataclasses
+import hashlib
+import zipfile
+from typing import Any
+
+from kani.models import BaseModel, ChatMessage
+from kani.utils.typing import PathLike
+
+
+# ==== main ====
+class SavedKani(BaseModel):
+    version: int = 1
+    always_included_messages: list[ChatMessage]
+    chat_history: list[ChatMessage]
+
+    def model_dump(self, **kwargs) -> dict[str, Any]:
+        return super().model_dump(serialize_as_any=True, **kwargs)
+
+    def model_dump_json(self, **kwargs) -> str:
+        return super().model_dump_json(serialize_as_any=True, **kwargs)
+
+
+def save(fp: PathLike, inst, *, save_format: str, **kwargs):
+    # create a Pydantic model for the saved attrs
+    data = SavedKani(always_included_messages=inst.always_included_messages, chat_history=inst.chat_history)
+
+    if save_format == "kani":
+        # zip w/ manifest file for multimodal attachments
+        with zipfile.ZipFile(fp, mode="w", compression=zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+            ctx = KaniZipSaveContext(zf=zf)
+            # the model_dump_json should write to zf when SAVELOAD_CONTEXT_KEY is provided
+            index = data.model_dump_json(context={SAVELOAD_CONTEXT_KEY: ctx}, **kwargs)
+            with zf.open("index.json", mode="w") as f:
+                f.write(index.encode("utf-8"))
+
+    elif save_format == "json":
+        # save using legacy JSON
+        with open(fp, "w", encoding="utf-8") as f:
+            f.write(data.model_dump_json(**kwargs))
+    else:
+        raise ValueError("save_format must be either 'kani' or 'json'.")
+
+
+def load(fp: PathLike, **kwargs) -> SavedKani:
+    # test file format
+    if zipfile.is_zipfile(fp):
+        # zipfile
+        with zipfile.ZipFile(fp, mode="r") as zf:
+            ctx = KaniZipSaveContext(zf=zf)
+            with zf.open("index.json") as f:
+                data = f.read().decode(encoding="utf-8")
+            return SavedKani.model_validate_json(data, context={SAVELOAD_CONTEXT_KEY: ctx}, **kwargs)
+    else:
+        # json
+        with open(fp, encoding="utf-8") as f:
+            data = f.read()
+        return SavedKani.model_validate_json(data, **kwargs)
+
+
+# ==== zip mode ====
+# to utilize multi-file saving, a model that is being saved (usually a MessagePart) should use a wrap-mode model
+# serializer and check for this key in the serializationinfo.context object
+SAVELOAD_CONTEXT_KEY = "kani.saveload.context"
+
+
+@dataclasses.dataclass
+class KaniZipSaveContext:
+    zf: zipfile.ZipFile
+
+    def save_bytes(self, data: bytes, suffix: str = "") -> str:
+        """
+        Save the given bytes to the zip file and return its path.
+        Filename is automatically determined by SHA256 hash.
+        If *suffix* is given, the filename will end with the given suffix.
+        """
+        the_hash = hashlib.sha256(data)
+        digest = the_hash.hexdigest()
+        fp = f"blobs/{digest[:2]}/{digest}{suffix}"
+        with self.zf.open(fp, mode="w") as f:
+            f.write(data)
+        return fp
+
+    def load_bytes(self, fp: str) -> bytes:
+        """
+        Read the bytes from the given path in the archive.
+        """
+        with self.zf.open(fp, mode="r") as f:
+            return f.read()
+
+
+def get_ctx(info) -> KaniZipSaveContext | None:
+    """Get the KaniZipSaveContext from a SerializationInfo/ValidationInfo object."""
+    if info.context and SAVELOAD_CONTEXT_KEY in info.context:
+        ctx = info.context[SAVELOAD_CONTEXT_KEY]
+        assert isinstance(ctx, KaniZipSaveContext)
+        return ctx
+    return None

--- a/kani/utils/saveload.py
+++ b/kani/utils/saveload.py
@@ -13,12 +13,6 @@ class SavedKani(BaseModel):
     always_included_messages: list[ChatMessage]
     chat_history: list[ChatMessage]
 
-    def model_dump(self, **kwargs) -> dict[str, Any]:
-        return super().model_dump(serialize_as_any=True, **kwargs)
-
-    def model_dump_json(self, **kwargs) -> str:
-        return super().model_dump_json(serialize_as_any=True, **kwargs)
-
 
 def save(fp: PathLike, inst, *, save_format: str, **kwargs):
     # create a Pydantic model for the saved attrs

--- a/kani/utils/typing.py
+++ b/kani/utils/typing.py
@@ -1,11 +1,3 @@
 import os
 
-from ..models import BaseModel, ChatMessage
-
 PathLike = str | bytes | os.PathLike
-
-
-class SavedKani(BaseModel):
-    version: int = 1
-    always_included_messages: list[ChatMessage]
-    chat_history: list[ChatMessage]

--- a/tests/test_saveload.py
+++ b/tests/test_saveload.py
@@ -1,5 +1,6 @@
 """Save -> load should be an identity transformation."""
 
+import pytest
 from hypothesis import HealthCheck, given, settings, strategies as st
 
 from kani import ChatMessage, FunctionCall, Kani, MessagePart
@@ -10,7 +11,8 @@ engine = TestEngine()
 
 @settings(suppress_health_check=(HealthCheck.function_scoped_fixture, HealthCheck.too_slow), deadline=None)
 @given(st.data())
-async def test_saveload_str(tmp_path, data):
+@pytest.mark.parametrize("save_format", ("json", "kani"))
+async def test_saveload_str(save_format, tmp_path, data):
     """Test that basic string content messages are saved."""
     # randomly initialize a kani state
     ai = Kani(
@@ -24,16 +26,17 @@ async def test_saveload_str(tmp_path, data):
         await ai.chat_round_str(query, test_echo=True)
 
     # save and load
-    ai.save(tmp_path / "pytest.json")
+    ai.save(tmp_path / f"pytest.{save_format}", save_format=save_format)
     loaded = Kani(engine)
-    loaded.load(tmp_path / "pytest.json")
+    loaded.load(tmp_path / f"pytest.{save_format}")
 
     # assert equality
     assert ai.always_included_messages == loaded.always_included_messages
     assert ai.chat_history == loaded.chat_history
 
 
-async def test_saveload_tool_calls(tmp_path):
+@pytest.mark.parametrize("save_format", ("json", "kani"))
+async def test_saveload_tool_calls(save_format, tmp_path):
     """Test that tool calls are saved."""
     fewshot = [
         ChatMessage.user("What's the weather in Philadelphia?"),
@@ -52,9 +55,9 @@ async def test_saveload_tool_calls(tmp_path):
     ai = Kani(engine, chat_history=fewshot)
 
     # save and load
-    ai.save(tmp_path / "pytest.json")
+    ai.save(tmp_path / f"pytest.{save_format}", save_format=save_format)
     loaded = Kani(engine)
-    loaded.load(tmp_path / "pytest.json")
+    loaded.load(tmp_path / f"pytest.{save_format}")
 
     # assert equality
     assert ai.always_included_messages == loaded.always_included_messages
@@ -69,7 +72,8 @@ class _TestMessagePart2(MessagePart):
     data: str
 
 
-async def test_saveload_messageparts(tmp_path):
+@pytest.mark.parametrize("save_format", ("json", "kani"))
+async def test_saveload_messageparts(save_format, tmp_path):
     """Test that message parts are serialized and deserialized into the right classes."""
     apart1 = _TestMessagePart1(data="apart1")
     apart2 = _TestMessagePart2(data="apart2")
@@ -95,9 +99,9 @@ async def test_saveload_messageparts(tmp_path):
     )
 
     # save and load
-    ai.save(tmp_path / "pytest.json")
+    ai.save(tmp_path / f"pytest.{save_format}", save_format=save_format)
     loaded = Kani(engine)
-    loaded.load(tmp_path / "pytest.json")
+    loaded.load(tmp_path / f"pytest.{save_format}")
 
     # assert equality
     assert ai.always_included_messages == loaded.always_included_messages


### PR DESCRIPTION
- Added a `save_format` parameter to `Kani.save()` to allow saving to a `.kani` file instead of `.json`
	- Saving to a `.kani` file is used unless the filename given to `Kani.save()` ends with `.json`
	- A `.kani` file is a ZIP file containing the saved chat state of the Kani instance
	- Certain extensions (e.g., `kani-multimodal-core`) may save additional files to the `.kani` archive to save multimodal MessageParts without inflating the size of the saved JSON file